### PR TITLE
Fix a transcription error (e→è, as unlikely as it seems)

### DIFF
--- a/exclusively_for_testing/probstei_106e2b3716da820f7f419e7f3e579d18.gt.txt
+++ b/exclusively_for_testing/probstei_106e2b3716da820f7f419e7f3e579d18.gt.txt
@@ -1,1 +1,1 @@
-Winter zuweilen große Schwärme wilder Gänſe ein.
+Winter zuweilen große Schwärme wildèr Gänſe ein.


### PR DESCRIPTION
I am not sure about this one. The image (as well as the OCR) clearly indicates *è* here:
![image](https://user-images.githubusercontent.com/26707219/70636597-1b4c0500-1c36-11ea-9962-8935ecb1b450.png)
But it might also be a binarization artifact. Can we somehow consult the source image?